### PR TITLE
bytt från "kontakta oss" till "kontakt" i headern

### DIFF
--- a/till-salu.html
+++ b/till-salu.html
@@ -22,7 +22,7 @@
                         <li><a class="a-hover" href="buy.html">Köpa<br>Fastighet</a></li>
                         <li><a class="a-hover" href="salja-fastigheter/salja-fastigheter.html">Sälja<br>Fastighet</a></li>
                         <li><a class="a-hover" href="till-salu.html">Fastigheter<br>Till Salu</a></li>
-                        <li><a class="a-hover" href="contact.html">Kontakta<br>oss</a></li>
+                        <li><a class="a-hover" href="contact.html"><br>Kontakt</a></li>
                     </ul>
                 </nav>
             </header>


### PR DESCRIPTION
Ändrade från "kontakta oss" till "kontakt" i headern.

Om ni vill ha så alla länkar är på två rader istället för en (som jag har i headern) så är det bara gå in i min kod och kopiera hela <ul> från headern.
Eller så kan ni skriva in <br> (break row) i texten på samma sätt som jag gjort.

Om ni gör det så kommer dem alltid att vara två rader och då hamnar strecket (som kommer när man hovrar på länken) på samma höjd på alla  länkarna. Just nu när jag lägger era sidor på 1200px så är det som att 'fastigheter till salu' är en nivå lägre ner än de andra länkarna.

Det kommer inte förstöra er kod alls, (har testat) utan ser bara med enhetligt och läsvänligt ut när länkarna inte hoppar mellan en och två rader hela tiden :)